### PR TITLE
fix: include baseUrl in mock config

### DIFF
--- a/src/mocks/sanityClient/mockSanityClient.ts
+++ b/src/mocks/sanityClient/mockSanityClient.ts
@@ -73,6 +73,7 @@ export function createMockSanityClient(
 
   const mockConfig = {
     useCdn: false,
+    baseUrl: 'http://mock-project-id.sanity.api/v1',
     projectId: 'mock-project-id',
     dataset: 'mock-data-set',
     apiVersion: '1',


### PR DESCRIPTION
Certain code locations depends on the [baseUrl](https://github.com/sanity-io/sanity/blob/92977a750b0924f01d24ccd988ba6cd9c139f72f/packages/sanity/src/core/config/prepareConfig.ts#L228) property of the config. This adds one to the mock config.